### PR TITLE
31-FEAT-album-remove-handler

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "java.compile.nullAnalysis.mode": "automatic",
-  "java.configuration.updateBuildConfiguration": "automatic"
+  "java.configuration.updateBuildConfiguration": "automatic",
+  "terminal.integrated.cwd": "${workspaceFolder}/jogakbo"
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumController.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumController.java
@@ -121,4 +121,15 @@ public class AlbumController {
 
     return ResponseEntity.ok(result);
   }
+
+  @Operation(description = "웹소켓 테스트 메소드 입니다.")
+  @MessageMapping("/test/{albumID}")
+  @SendTo("/sub/test/{albumID}")
+  public String testWebSocket(@DestinationVariable String albumID, String payload)
+      throws Exception {
+
+    log.info("albumID : " + albumID);
+
+    return payload;
+  }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumController.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumController.java
@@ -1,5 +1,6 @@
 package com.noyes.jogakbo.album;
 
+import java.io.IOException;
 import java.security.Principal;
 import java.util.List;
 
@@ -118,6 +119,15 @@ public class AlbumController {
       Principal principal) {
 
     String result = albumService.updateProfile(albumID, newAlbumName, thumbnailImage, principal.getName());
+
+    return ResponseEntity.ok(result);
+  }
+
+  @Operation(description = "앨범 삭제 메서드입니다.")
+  @DeleteMapping("/{albumID}")
+  public ResponseEntity<String> removeAlbum(@PathVariable String albumID, Principal principal) throws IOException {
+
+    String result = albumService.removeAlbum(albumID, principal.getName());
 
     return ResponseEntity.ok(result);
   }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumService.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumService.java
@@ -253,4 +253,27 @@ public class AlbumService {
 
     return "앨범 삭제 작업을 완료했습니다.";
   }
+
+  /**
+   * 유저가 albumEditors 에 속해있는지 검증
+   * 
+   * @param albumID
+   * @param socialID
+   * @return
+   */
+  public Boolean validAlbumEditor(String albumID, String socialID) {
+
+    // DB에서 albumID로 Album 객체 접근 후, albumEditors 필드 추출
+    List<String> albumEditors = albumRepository.findById(albumID).get().getAlbumEditors();
+
+    // 순회를 돌며 인자로 받은 socialID가 List에 포함되어 있다면 true를 반환
+    for (String albumEditor : albumEditors) {
+
+      if (albumEditor.equals(socialID))
+        return true;
+    }
+
+    // List에 포함되어 있지 않았으므로 false를 반환
+    return false;
+  }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/redis/RedisService.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/redis/RedisService.java
@@ -28,4 +28,14 @@ public class RedisService {
 
     return objectMapper.readValue(redisValue, classType);
   }
+
+  /**
+   * Album data of albumID will be removed in redis.
+   * 
+   * @param
+   */
+  public void removeAlbumRedisValue(String albumID) {
+
+    redisTemplate.delete(albumID);
+  }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/FilterChannelInterceptor.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/FilterChannelInterceptor.java
@@ -53,6 +53,15 @@ public class FilterChannelInterceptor implements ChannelInterceptor {
 
       SecurityContextHolder.getContext().setAuthentication(authentication);
       headerAccessor.setUser(authentication);
+
+    } else if (headerAccessor.getCommand() == StompCommand.SUBSCRIBE) {
+
+      // headerAccessor 에서 sessionID와 albumID 추출
+      String sessionID = headerAccessor.getSessionId();
+      String albumID = headerAccessor.getDestination().split("/")[3];
+
+      // sessionID에 구독 albumID를 경로를 업데이트
+      WebSocketSessionHolder.updateSessionWithDestination(sessionID, albumID);
     }
 
     return message;

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/FilterChannelInterceptor.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/FilterChannelInterceptor.java
@@ -62,6 +62,12 @@ public class FilterChannelInterceptor implements ChannelInterceptor {
 
       // sessionID에 구독 albumID를 경로를 업데이트
       WebSocketSessionHolder.updateSessionWithDestination(sessionID, albumID);
+
+    } else if (headerAccessor.getCommand() == StompCommand.DISCONNECT) {
+
+      // 관리 대상에서 특정 sessionID 제거
+      String sessionID = headerAccessor.getSessionId();
+      WebSocketSessionHolder.removeSession(sessionID);
     }
 
     return message;

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/FilterChannelInterceptor.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/FilterChannelInterceptor.java
@@ -35,24 +35,26 @@ public class FilterChannelInterceptor implements ChannelInterceptor {
 
     assert headerAccessor != null;
     if (headerAccessor.getCommand() == StompCommand.CONNECT) {
+
       String token = String.valueOf(headerAccessor.getNativeHeader("Authorization").get(0));
       log.info("소켓 접속 요청 token 값 확인 : " + token);
+
+      String password = PasswordUtil.generateRandomPassword();
+
+      UserDetails userDetailsUser = User.builder()
+          .username("myUser.getSocialId()")
+          .password(password)
+          // .roles(myUser.getRole().name())
+          .roles("USER")
+          .build();
+
+      Authentication authentication = new UsernamePasswordAuthenticationToken(userDetailsUser, null,
+          authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+      headerAccessor.setUser(authentication);
     }
 
-    String password = PasswordUtil.generateRandomPassword();
-
-    UserDetails userDetailsUser = User.builder()
-        .username("myUser.getSocialId()")
-        .password(password)
-        // .roles(myUser.getRole().name())
-        .roles("USER")
-        .build();
-
-    Authentication authentication = new UsernamePasswordAuthenticationToken(userDetailsUser, null,
-        authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
-
-    SecurityContextHolder.getContext().setAuthentication(authentication);
-    headerAccessor.setUser(authentication);
     return message;
   }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketConfig.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketConfig.java
@@ -3,9 +3,14 @@ package com.noyes.jogakbo.global.websocket;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
+import org.springframework.web.socket.handler.WebSocketHandlerDecorator;
+import org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,5 +35,26 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void configureClientInboundChannel(ChannelRegistration registration) {
     registration.interceptors(filterChannelInterceptor);
+  }
+
+  @Override
+  public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
+    registration.addDecoratorFactory(new WebSocketHandlerDecoratorFactory() {
+
+      @Override
+      public WebSocketHandler decorate(final WebSocketHandler handler) {
+        return new WebSocketHandlerDecorator(handler) {
+
+          @Override
+          public void afterConnectionEstablished(final WebSocketSession session) throws Exception {
+
+            // 현재 세션을 WebSocketSessionHolder 에 등록
+            WebSocketSessionHolder.registSession(session);
+
+            super.afterConnectionEstablished(session);
+          }
+        };
+      }
+    });
   }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
@@ -2,64 +2,70 @@ package com.noyes.jogakbo.global.websocket;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.List;
 import java.io.IOException;
-import java.util.ArrayList;
 
-import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketSession;
 
 public class WebSocketSessionHolder {
 
   static {
-    sessionIDsByDest = new ConcurrentHashMap<>();
     userSessions = new ConcurrentHashMap<>();
   }
 
-  // key - username, value - List of user's sessions
-  private static Map<String, List<String>> sessionIDsByDest;
-  private static Map<String, WebSocketSession> userSessions;
+  // Key 값 으로 sessionID, Value로 WebSocketInfo 를 가지는 Map 선언
+  private static Map<String, WebSocketSessionInfo> userSessions;
 
+  /**
+   * <pre>
+   * regist session into ConcurrentHashMap, userSessions.
+   * expect destination will be updated when client subscribe album.
+   * </pre>
+   * 
+   * @param session
+   */
   public static void registSession(WebSocketSession session) {
 
-    userSessions.put(session.getId(), session);
+    WebSocketSessionInfo webSocketSessionInfo = WebSocketSessionInfo.builder().session(session).build();
+    userSessions.put(session.getId(), webSocketSessionInfo);
   }
 
-  public static void addSessionByDestination(String sessionID, String destination) {
+  /**
+   * update WebSocketSessionInfo's destination field with sessionID
+   * 
+   * @param sessionID
+   * @param destination
+   */
+  public static void updateSessionWithDestination(String sessionID, String destination) {
 
-    // 처음 등록되는 destination 이면, 새로운 ArrayList 할당 후 등록
-    var sessionIDs = sessionIDsByDest.get(destination);
-
-    if (sessionIDs == null)
-      sessionIDs = new ArrayList<String>();
-
-    // destination 을 키 값으로 sessionID를 추가
-    sessionIDs.add(sessionID);
-    sessionIDsByDest.put(destination, sessionIDs);
+    // sessionID 에 해당하는 WebSocketSessionInfo 객체에 destination 필드 업데이트
+    var webSocketSessionInfo = userSessions.get(sessionID);
+    webSocketSessionInfo.setDestination(destination);
   }
 
+  /**
+   * remove WebSocketSesssionInfo in ConcurrentHashMap, userSessions
+   * 
+   * @param sessionID
+   */
   public static void removeSession(String sessionID) {
 
     userSessions.remove(sessionID);
   }
 
+  /**
+   * close WebSocketSession corresponding destination field
+   * 
+   * @param destination
+   * @throws IOException
+   */
   public static void closeSessionByDestination(String destination) throws IOException {
 
-    var sessionIDs = sessionIDsByDest.get(destination);
+    // sessionIDs를 순회하며 destination 에 해당하는 WebSocketSession을 close()
+    for (var entry : userSessions.entrySet()) {
 
-    if (sessionIDs != null) {
-      // sessionIDs를 순회하며 해당하는 WebSocketSession을 close()
-      for (var sessionID : sessionIDs) {
-        // session 이 살아있다면, userSessions 에서 제거
-        var session = userSessions.get(sessionID);
-
-        if (session != null) {
-
-          session.close(CloseStatus.GOING_AWAY);
-        }
-      }
-      // 마지막으로 sessionIDsByDest 에서 제거
-      sessionIDsByDest.remove(destination);
+      String targetDest = entry.getValue().getDestination();
+      if (targetDest != null && targetDest.equals(destination))
+        entry.getValue().getSession().close();
     }
   }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
@@ -36,6 +36,11 @@ public class WebSocketSessionHolder {
     sessionIDsByDest.put(sessionID, sessionIDs);
   }
 
+  public static void removeSession(WebSocketSession session) {
+
+    userSessions.remove(session.getId());
+  }
+
   public static void closeSessionByDestination(String destination) throws IOException {
 
     var sessionIDs = sessionIDsByDest.get(destination);

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
@@ -65,9 +65,6 @@ public class WebSocketSessionHolder {
         if (session != null) {
 
           session.close(CloseStatus.GOING_AWAY);
-
-          // userSessions 에서도 제거
-          userSessions.remove(sessionID);
         }
       }
       // 마지막으로 sessionIDsByDest 에서 제거

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
@@ -38,17 +38,8 @@ public class WebSocketSessionHolder {
     sessionIDsByDest.put(destination, sessionIDs);
   }
 
-  public static void removeSession(String sessionID, String destination) {
+  public static void removeSession(String sessionID) {
 
-    // sessionsIDsByDest 에서 destination 에 존재하는 sessionID를 제거
-    var sessions = sessionIDsByDest.get(destination);
-    for (var session : sessions) {
-
-      if (session.equals(sessionID))
-        sessionIDsByDest.remove(session);
-    }
-
-    // userSessions 에서도 해당 WebSocketSession 제거
     userSessions.remove(sessionID);
   }
 

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
@@ -27,13 +27,15 @@ public class WebSocketSessionHolder {
 
   public static void addSessionByDestination(String sessionID, String destination) {
 
+    // 처음 등록되는 destination 이면, 새로운 ArrayList 할당 후 등록
     var sessionIDs = sessionIDsByDest.get(destination);
 
     if (sessionIDs == null)
       sessionIDs = new ArrayList<String>();
 
+    // destination 을 키 값으로 sessionID를 추가
     sessionIDs.add(sessionID);
-    sessionIDsByDest.put(sessionID, sessionIDs);
+    sessionIDsByDest.put(destination, sessionIDs);
   }
 
   public static void removeSession(WebSocketSession session) {

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
@@ -38,9 +38,18 @@ public class WebSocketSessionHolder {
     sessionIDsByDest.put(destination, sessionIDs);
   }
 
-  public static void removeSession(WebSocketSession session) {
+  public static void removeSession(String sessionID, String destination) {
 
-    userSessions.remove(session.getId());
+    // sessionsIDsByDest 에서 destination 에 존재하는 sessionID를 제거
+    var sessions = sessionIDsByDest.get(destination);
+    for (var session : sessions) {
+
+      if (session.equals(sessionID))
+        sessionIDsByDest.remove(session);
+    }
+
+    // userSessions 에서도 해당 WebSocketSession 제거
+    userSessions.remove(sessionID);
   }
 
   public static void closeSessionByDestination(String destination) throws IOException {

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
@@ -1,0 +1,54 @@
+package com.noyes.jogakbo.global.websocket;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.List;
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+
+public class WebSocketSessionHolder {
+
+  static {
+    sessionIDsByDest = new ConcurrentHashMap<>();
+    userSessions = new ConcurrentHashMap<>();
+  }
+
+  // key - username, value - List of user's sessions
+  private static Map<String, List<String>> sessionIDsByDest;
+  private static Map<String, WebSocketSession> userSessions;
+
+  public static void registSession(WebSocketSession session) {
+
+    userSessions.put(session.getId(), session);
+  }
+
+  public static void addSessionByDestination(String sessionID, String destination) {
+
+    var sessionIDs = sessionIDsByDest.get(destination);
+
+    if (sessionIDs == null)
+      sessionIDs = new ArrayList<String>();
+
+    sessionIDs.add(sessionID);
+    sessionIDsByDest.put(sessionID, sessionIDs);
+  }
+
+  public static void closeSessionByDestination(String destination) throws IOException {
+
+    var sessionIDs = sessionIDsByDest.get(destination);
+
+    if (sessionIDs != null) {
+      // sessionIDs를 순회하며 해당하는 WebSocketSession을 close()
+      for (var sessionID : sessionIDs) {
+        // CloseStatus로 퇴장 상태 알리고 userSessions 에서 제거
+        userSessions.get(sessionID).close(CloseStatus.GOING_AWAY);
+        userSessions.remove(sessionID);
+      }
+      // 마지막으로 sessionIDsByDest 에서 제거
+      sessionIDsByDest.remove(destination);
+    }
+  }
+}

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionHolder.java
@@ -43,9 +43,16 @@ public class WebSocketSessionHolder {
     if (sessionIDs != null) {
       // sessionIDs를 순회하며 해당하는 WebSocketSession을 close()
       for (var sessionID : sessionIDs) {
-        // CloseStatus로 퇴장 상태 알리고 userSessions 에서 제거
-        userSessions.get(sessionID).close(CloseStatus.GOING_AWAY);
-        userSessions.remove(sessionID);
+        // session 이 살아있다면, userSessions 에서 제거
+        var session = userSessions.get(sessionID);
+
+        if (session != null) {
+
+          session.close(CloseStatus.GOING_AWAY);
+
+          // userSessions 에서도 제거
+          userSessions.remove(sessionID);
+        }
       }
       // 마지막으로 sessionIDsByDest 에서 제거
       sessionIDsByDest.remove(destination);

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionInfo.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/websocket/WebSocketSessionInfo.java
@@ -1,0 +1,14 @@
+package com.noyes.jogakbo.global.websocket;
+
+import org.springframework.web.socket.WebSocketSession;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class WebSocketSessionInfo {
+
+  private WebSocketSession session;
+  private String destination;
+}

--- a/jogakbo/src/main/resources/static/index.html
+++ b/jogakbo/src/main/resources/static/index.html
@@ -1,72 +1,171 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Title</title>
+    <title>Simple Chat Application using StompJs</title>
+    <link type="text/css" rel="stylesheet" href="../../assets/style.css" />
   </head>
   <body>
-    <input
-      type="text"
-      placeholder="보낼 메세지를 입력하세요."
-      class="content"
-    />
-    <button type="button" value="전송" class="sendBtn" onclick="sendMsg()">
-      전송
-    </button>
-    <button type="button" value="방나가기" class="quit" onclick="quit()">
-      방 나가기
-    </button>
-    <div>
-      <span>메세지</span>
-      <div class="msgArea"></div>
+    <div id="wrapper">
+      <ul>
+        <li>Open multiple browsers or tabs to chat across those.</li>
+        <li>
+          You will need a STOMP broker running. The defaults will work for fresh
+          RabbitMQ on local machine.
+        </li>
+        <li>
+          Adjust the
+          <a
+            href="https://stomp-js.github.io/api-docs/latest/classes/StompConfig.html"
+            >configuration</a
+          >
+          as per your STOMP broker.
+        </li>
+        <li>
+          A guide at
+          <a
+            href="https://stomp-js.github.io/guide/stompjs/2018/06/28/using-stompjs-v5.html"
+          >
+            Using StompJs v5</a
+          >
+        </li>
+        <li>
+          For details on API calls see:
+          <a
+            href="https://stomp-js.github.io/api-docs/latest/classes/Client.html"
+          >
+            API Reference</a
+          >
+        </li>
+        <li>
+          The html/css is heavily based on
+          <a
+            href="https://code.tutsplus.com/tutorials/how-to-create-a-simple-web-based-chat-application--net-5931"
+          >
+            Simple Web-Based Chat Application</a
+          >
+        </li>
+      </ul>
+      <div id="menu">
+        <p class="welcome">
+          Welcome,
+          <input
+            title="username"
+            name="username"
+            id="username"
+            type="text"
+            value="Change Me"
+          />
+        </p>
+      </div>
+
+      <div id="chatbox"></div>
+
+      <input
+        name="usermsg"
+        type="text"
+        id="usermsg"
+        size="63"
+        title="usermsg"
+      />
+      <button name="submitmsg" id="submitmsg">Send</button>
     </div>
+
+    <!-- It is used for DOM manipulation, not mandatory to use stompjs -->
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
+
+    <!-- Include from CDN for better performance, alternatively you can locally copy as well -->
+    <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7.0.0-beta2/bundles/stomp.umd.min.js"></script>
+
+    <script type="application/javascript">
+      $(function () {
+        let stompClient;
+        let accessToken = "";
+
+        const stompConfig = {
+          // Broker URL, should start with ws:// or wss:// - adjust for your broker setup
+          brokerURL: "ws://localhost:8080/album-ws",
+
+          // Typically, login, passcode and vhost
+          // Adjust these for your broker
+          connectHeaders: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+
+          // Keep it off for production, it can be quit verbose
+          // Skip this key to disable
+          debug: function (str) {
+            console.log("STOMP: " + str);
+          },
+
+          // If disconnected, it will retry after 200ms
+          reconnectDelay: 200,
+
+          // Subscriptions should be done inside onConnect as those need to reinstated when the broker reconnects
+          onConnect: function (frame) {
+            // The return object has a method called `unsubscribe`
+            const subscription = stompClient.subscribe(
+              "/sub/test/testest",
+              function (message) {
+                const payload = JSON.parse(message.body);
+                displayIncomingMessage(payload.user, payload.usrMsg);
+              }
+            );
+          },
+        };
+
+        // Create an instance
+        stompClient = new StompJs.Client(stompConfig);
+
+        // You can set additional configuration options here
+
+        // Attempt to connect
+        stompClient.activate();
+
+        // For the demo, set a random display user name for the chat, just feels nice
+        $("#username").val("User " + Math.round(Math.random() * 100));
+
+        // Set the DOM event handlers must not be inside onConnect - other for each reconnect it will keep getting added
+        $("#submitmsg").click(function () {
+          if (publishMessage($("#username").val(), $("#usermsg").val())) {
+            clearMessageInput();
+          }
+        });
+
+        function clearMessageInput() {
+          $("#usermsg").val("");
+        }
+
+        function publishMessage(user, message) {
+          // trying to publish a message when the broker is not connected will throw an exception
+          if (!stompClient.connected) {
+            alert("Broker disconnected, can't send message.");
+            return false;
+          }
+          if (message.length > 0) {
+            const payLoad = { user: user, usrMsg: message };
+
+            // You can additionally pass headers
+            stompClient.publish({
+              destination: "/pub/test/testest",
+              body: JSON.stringify(payLoad),
+            });
+          }
+          return true;
+        }
+
+        function displayIncomingMessage(user, message) {
+          const msgDiv = $("<div>").addClass("msgln");
+          msgDiv.html(
+            '<span class="user">[' +
+              user +
+              ']: </span><span class="message">' +
+              message +
+              "</span>"
+          );
+          $("#chatbox").append(msgDiv);
+        }
+      });
+    </script>
   </body>
-
-  <script th:inline="javascript">
-    function enterRoom(socket) {
-      var enterMsg = {
-        type: "ENTER",
-        roomId: "1",
-        sender: "chee",
-        msg: "test",
-      }; //sender는  글쓸때 수정하자.
-      socket.send(JSON.stringify(enterMsg));
-    }
-    let socket = new WebSocket("ws://localhost:8080/ws/album");
-
-    socket.onopen = function (e) {
-      console.log("open server!");
-      enterRoom(socket);
-    };
-    socket.onclose = function (e) {
-      console.log("disconnet");
-    };
-
-    socket.onerror = function (e) {
-      console.log(e);
-    };
-
-    //메세지 수신했을 때 이벤트.
-    socket.onmessage = function (e) {
-      console.log(e.data);
-      let msgArea = document.querySelector(".msgArea");
-      let newMsg = document.createElement("div");
-      newMsg.innerText = e.data;
-      msgArea.append(newMsg);
-    };
-
-    //메세지 보내기 버튼 눌렀을 떄..
-    function sendMsg() {
-      let content = document.querySelector(".content").value;
-      var talkMsg = { type: "TALK", roomId: "1", sender: "chee", msg: content };
-      socket.send(JSON.stringify(talkMsg));
-    }
-
-    function quit() {
-      var quitMsg = { type: "QUIT", roomId: "1", sender: "chee", msg: "" };
-      socket.send(JSON.stringify(quitMsg));
-      socket.close();
-      location.href = "/chat/chatList";
-    }
-  </script>
 </html>


### PR DESCRIPTION
**Related issue**

#31 #32

**Key changes**

> New album remove API

works with following steps

1. request delete method with albumID as path parameter

2. service logic will verify client is albumOwner or not (will be rejected if not)

3. service will block addtional entrance to album

4. album co-workers will be kicked with notification

5. all data related to album will be removed permanantly

> User validation in websocket

- from now on, only user can connect to websocket
- only co-worker added in `albumEditors` can subscribe to album

**Additional context**


**To Reviewers**
Need double check `deleteFile` method in `removeAlbum` when refactor for S3 asset management