### PR TITLE
:recycle: Refactor: update AwsS3Service with prefix

### DIFF
--- a/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumService.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumService.java
@@ -97,7 +97,7 @@ public class AlbumService {
       throws JsonProcessingException {
 
     // S3에 업로드 시도 후, 업로드 된 S3 파일명 리스트로 받아오기
-    List<String> uploadFileNames = awsS3Service.uploadFiles(multipartFiles);
+    List<String> uploadFileNames = awsS3Service.uploadFiles(multipartFiles, albumID);
 
     ObjectMapper objectMapper = new ObjectMapper();
     List<ImageInfo> imageInfos = objectMapper.readValue(fileInfos, new TypeReference<List<ImageInfo>>() {
@@ -144,7 +144,7 @@ public class AlbumService {
     }
     redisService.setAlbumRedisValue(albumID, targetInfo);
 
-    awsS3Service.deleteFile(imageUUID);
+    awsS3Service.deleteFile(imageUUID, albumID);
 
     return imagesInfo;
   }
@@ -208,7 +208,7 @@ public class AlbumService {
     if (thumnailImage != null && !thumnailImage.getOriginalFilename().equals(thumbnailOriginalName)) {
 
       // S3에 업로드 시도 후, 업로드 된 S3 파일명 받아오기
-      String uploadFileName = awsS3Service.uploadFile(thumnailImage);
+      String uploadFileName = awsS3Service.uploadFile(thumnailImage, albumID);
 
       album.setThumbnailImage(uploadFileName);
       album.setThumbnailOriginalName(thumbnailOriginalName);
@@ -244,7 +244,7 @@ public class AlbumService {
     for (List<ImagesInPage> imagesInfoOfIndex : imagesInfo) {
       for (ImagesInPage imageInfo : imagesInfoOfIndex) {
 
-        awsS3Service.deleteFile(imageInfo.getImageUUID());
+        awsS3Service.deleteFile(imageInfo.getImageUUID(), albumID);
       }
     }
 

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/s3/AwsS3Service.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/s3/AwsS3Service.java
@@ -35,15 +35,17 @@ public class AwsS3Service {
    * @return result
    * @throws ResponseStatusException
    */
-  public String uploadFile(MultipartFile multipartFile) {
+  public String uploadFile(MultipartFile multipartFile, String prefix) {
 
     String fileName = createFileName(multipartFile.getOriginalFilename());
+    String uploadFileName = prefix + "/" + fileName;
+
     ObjectMetadata objectMetadata = new ObjectMetadata();
     objectMetadata.setContentLength(multipartFile.getSize());
     objectMetadata.setContentType(multipartFile.getContentType());
 
     try (InputStream inputStream = multipartFile.getInputStream()) {
-      amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+      amazonS3.putObject(new PutObjectRequest(bucket, uploadFileName, inputStream, objectMetadata)
           .withCannedAcl(CannedAccessControlList.PublicRead));
     } catch (IOException e) {
       throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
@@ -59,25 +61,28 @@ public class AwsS3Service {
    * @return result
    * @throws ResponseStatusException
    */
-  public List<String> uploadFiles(List<MultipartFile> multipartFiles) {
+  public List<String> uploadFiles(List<MultipartFile> multipartFiles, String prefix) {
 
     List<String> fileNameList = new ArrayList<>();
 
     // forEach 구문을 통해 multipartFiles 리스트로 넘어온 파일들을 순차적으로 fileNameList 에 추가
     multipartFiles.forEach(file -> {
+
       String fileName = createFileName(file.getOriginalFilename());
+      String uploadFileName = prefix + "/" + fileName;
+
       ObjectMetadata objectMetadata = new ObjectMetadata();
       objectMetadata.setContentLength(file.getSize());
       objectMetadata.setContentType(file.getContentType());
 
       try (InputStream inputStream = file.getInputStream()) {
-        amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+        amazonS3.putObject(new PutObjectRequest(bucket, uploadFileName, inputStream, objectMetadata)
             .withCannedAcl(CannedAccessControlList.PublicRead));
       } catch (IOException e) {
         throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
       }
-      fileNameList.add(fileName);
 
+      fileNameList.add(fileName);
     });
 
     return fileNameList;
@@ -98,8 +103,10 @@ public class AwsS3Service {
     }
   }
 
-  public void deleteFile(String fileName) {
-    amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+  public void deleteFile(String fileName, String prefix) {
+
+    String uploadFileName = prefix + "/" + fileName;
+    amazonS3.deleteObject(new DeleteObjectRequest(bucket, uploadFileName));
     System.out.println(bucket);
   }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/user/UserService.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/user/UserService.java
@@ -517,7 +517,7 @@ public class UserService {
     if (profileImage != null && !profileImageOriginalName.equals(profileImage.getOriginalFilename())) {
 
       // S3에 업로드 시도 후, 업로드 된 S3 파일명 리스트로 받아오기
-      String uploadFileName = awsS3Service.uploadFile(profileImage);
+      String uploadFileName = awsS3Service.uploadFile(profileImage, socialID);
 
       user.setProfileImageUrl(uploadFileName);
       user.setProfileImageOriginalName(profileImageOriginalName);


### PR DESCRIPTION
**Related issue**
resolves: #33

**Key changes**
> Group images in S3 with prefix

- images of albums are grouped by albumID
e.g. image1.png -> album1/image1.png

- user profile images are grouped by userID
e.g. profile.png -> user1/profile.png

**Additional context**


**To Reviewers**
- existing all images in S3 are removed
- whole test user and album infos in DB are removed