### PR TITLE
37-BUG-user-profile-images-are-never-removed-when-newly-updated

### DIFF
--- a/jogakbo/src/main/java/com/noyes/jogakbo/user/UserService.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/user/UserService.java
@@ -519,8 +519,9 @@ public class UserService {
       // S3에 업로드 시도 후, 업로드 된 S3 파일명 리스트로 받아오기
       String uploadFileName = awsS3Service.uploadFile(profileImage, socialID);
 
+      // 새로운 profileImage 정보로 User entity 업데이트
       user.setProfileImageUrl(uploadFileName);
-      user.setProfileImageOriginalName(profileImageOriginalName);
+      user.setProfileImageOriginalName(profileImage.getOriginalFilename());
 
       // 기존의 profileImage 삭제
       awsS3Service.deleteFile(profileImageOriginalName, socialID);


### PR DESCRIPTION
**Related issue**
fix #37
refer #36

**Key changes**
When update user profile image, formal profileImage was immortal.
Now, formal profileImage is removed well.
In addition, i found same bug with #36 in this `updateProfile` method.
So, corrected this bug same way with it

**Additional context**


**To Reviewers**
