### PR TITLE
[FEAT] album invitation

### DIFF
--- a/jogakbo/src/main/java/com/noyes/jogakbo/album/Album.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/album/Album.java
@@ -21,17 +21,15 @@ public class Album {
 
   @Id
   private String albumID;
-
   private String albumName;
-
   private String thumbnailImage;
   private String thumbnailOriginalName;
-
   private List<List<ImagesInPage>> images;
-
   private String albumOwner;
-
+  // field for album co-workers list
   private List<String> albumEditors;
+  // field for invited user list
+  private List<String> sentAlbumInvitations;
 
   @Version
   private int version;

--- a/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumController.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumController.java
@@ -159,4 +159,14 @@ public class AlbumController {
 
     return ResponseEntity.ok(result);
   }
+
+  @Operation(description = "앨범 초대 응답 엔드포인트입니다. reply 파라미터의 값이 accept 면 앨범에 참여하게 됩니다.")
+  @PostMapping("/invitation-reply/{albumID}")
+  public ResponseEntity<String> replyAlbumInvitation(@PathVariable String albumID, @RequestParam String reply,
+      Principal principal) {
+
+    String res = albumService.replyAlbumInvitation(albumID, principal.getName(), reply);
+
+    return ResponseEntity.ok(res);
+  }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumController.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumController.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.noyes.jogakbo.album.DTO.EditMessage;
 import com.noyes.jogakbo.album.DTO.EntryMessage;
 import com.noyes.jogakbo.album.DTO.ImagesInPage;
+import com.noyes.jogakbo.global.SseEmitters;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,6 +41,7 @@ public class AlbumController {
 
   private final AlbumService albumService;
   private final SimpMessagingTemplate simpMessageTemplate;
+  private final SseEmitters sseEmitters;
 
   @Operation(description = "앨범 등록 메서드입니다.")
   @PostMapping()
@@ -141,5 +143,20 @@ public class AlbumController {
     log.info("albumID : " + albumID);
 
     return payload;
+  }
+
+  @Operation(description = "앨범 초대 메서드입니다.")
+  @PostMapping("/invitation/{albumID}/{socialID}")
+  public ResponseEntity<String> sendAlbumInvitation(@PathVariable String albumID, @PathVariable String collaboUserID,
+      Principal principal) {
+
+    Album album = albumService.sendAlbumInvitation(albumID, collaboUserID, principal.getName());
+
+    if (album == null)
+      return ResponseEntity.ok("이미 친구이거나 요청을 보낸 상대입니다.");
+
+    String result = sseEmitters.sendAlbumInvitation(collaboUserID, album);
+
+    return ResponseEntity.ok(result);
   }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumController.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumController.java
@@ -146,7 +146,7 @@ public class AlbumController {
   }
 
   @Operation(description = "앨범 초대 메서드입니다.")
-  @PostMapping("/invitation/{albumID}/{socialID}")
+  @PostMapping("/invitation/{albumID}/{collaboUserID}")
   public ResponseEntity<String> sendAlbumInvitation(@PathVariable String albumID, @PathVariable String collaboUserID,
       Principal principal) {
 

--- a/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumService.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumService.java
@@ -288,4 +288,51 @@ public class AlbumService {
     // List에 포함되어 있지 않았으므로 false를 반환
     return false;
   }
+
+  /**
+   * collaboUserID에 해당하는 유저에게 앨범 초대 보내기
+   * 
+   * @param
+   * @return
+   */
+  public Album sendAlbumInvitation(String albumID, String collaboUserID, String socialID) {
+
+    // 요청자가 album의 소유자인지 검증
+    Album album = albumRepository.findById(albumID)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 앨범 ID 입니다."));
+
+    // 이미 요청을 보낸 대상일 경우 예외처리
+    List<String> sentAlbumInvitations = album.getSentAlbumInvitations();
+
+    if (isUserInList(sentAlbumInvitations, collaboUserID) != null)
+      return null;
+
+    // 이미 초대된 경우도 예외처리
+    List<String> albumEditors = album.getAlbumEditors();
+    if (isUserInList(albumEditors, collaboUserID) != null)
+      return null;
+
+    // 앨범 초대 리스트에 등록
+    sentAlbumInvitations.add(collaboUserID);
+    userService.addReceivedAlbumInvitations(collaboUserID, album);
+
+    albumRepository.save(album);
+
+    return album;
+  }
+
+  /**
+   * List에 collaboUserID가 존재하는지 판별
+   * 
+   * @param
+   */
+  public String isUserInList(List<String> stringList, String socialID) {
+
+    for (String stringPiece : stringList) {
+
+      if (stringPiece.equals(socialID))
+        return stringPiece;
+    }
+    return null;
+  }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumService.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumService.java
@@ -39,7 +39,16 @@ public class AlbumService {
 
   public EntryMessage getEntryMessage(String socialID, String albumID) throws JsonProcessingException {
 
-    Album album = userService.getAlbumByUser(socialID, albumID);
+    // 앨범 ID로 앨범 가져오기
+    Album album = albumRepository.findById(albumID)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유효하지 않은 앨범 ID 입니다."));
+
+    // 앨범 주인이거나 공동 작업자인지 확인
+    String albumOwner = album.getAlbumOwner();
+    List<String> albumEditors = album.getAlbumEditors();
+    if (!albumOwner.equals(socialID) && !albumEditors.contains(socialID))
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "앨범을 조회할 권한이 없습니다.");
+
     AlbumImagesInfo targetInfo = redisService.getAlbumRedisValue(albumID, AlbumImagesInfo.class);
     List<List<ImagesInPage>> imagesInfo = targetInfo.getImagesInfo();
 

--- a/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumService.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/album/AlbumService.java
@@ -20,6 +20,7 @@ import com.noyes.jogakbo.album.DTO.ImagesInPage;
 import com.noyes.jogakbo.global.redis.RedisService;
 import com.noyes.jogakbo.global.s3.AwsS3Service;
 import com.noyes.jogakbo.global.websocket.WebSocketSessionHolder;
+import com.noyes.jogakbo.user.User;
 import com.noyes.jogakbo.user.UserService;
 
 import lombok.NonNull;
@@ -322,6 +323,62 @@ public class AlbumService {
   }
 
   /**
+   * 응답 메세지에 따라 앨범 작업자로 추가 후, 초대 요청 리스트에서 이전 요청 제거
+   * 
+   * @param albumID
+   * @param resUserID
+   * @param reply
+   * @return result in String
+   */
+  public String replyAlbumInvitation(@NonNull String albumID, @NonNull String resUserID, String reply) {
+
+    // 보낸|받은 요청 유효성 판별 변수 추가
+    boolean isValidRequest = true;
+
+    // 초대 요청을 보낸 앨범인지 확인
+    Album requestAlbum = albumRepository.findById(albumID)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 앨범 ID 입니다."));
+
+    List<String> sentAlbumInvitations = requestAlbum.getSentAlbumInvitations();
+
+    String targetUser = isUserInList(sentAlbumInvitations, resUserID);
+
+    if (targetUser == null)
+      isValidRequest = false;
+
+    // 초대 요청을 받은 유저인지도 확인
+    User responseUser = userService.getUser(resUserID)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 유저 ID 입니다."));
+
+    List<Album> receivedAlbumInvitations = responseUser.getReceivedAlbumInvitations();
+
+    Album callAlbum = isAlbumInList(receivedAlbumInvitations, albumID);
+
+    if (callAlbum == null)
+      isValidRequest = false;
+
+    // 서로의 요청, 승인 대기열에서 삭제
+    sentAlbumInvitations.remove(targetUser);
+    userService.removeAlbumInvitation(resUserID, callAlbum.getAlbumID());
+
+    albumRepository.save(requestAlbum);
+
+    if (!isValidRequest)
+      return "더 이상 유효하지 않은 앨범 초대 요청입니다.";
+
+    // 서로의 목록에 추가
+    if (reply.equals("accept")) {
+
+      requestAlbum.getAlbumEditors().add(targetUser);
+      albumRepository.save(requestAlbum);
+
+      userService.addCollaboAlbum(resUserID, callAlbum);
+    }
+
+    return "요청이 성공적으로 반영되었습니다.";
+  }
+
+  /**
    * List에 collaboUserID가 존재하는지 판별
    * 
    * @param
@@ -332,6 +389,22 @@ public class AlbumService {
 
       if (stringPiece.equals(socialID))
         return stringPiece;
+    }
+    return null;
+  }
+
+  /**
+   * List에 동일한 albumID를 가지는 album이 존재하는지 판별
+   * 
+   * @param
+   * @return
+   */
+  public Album isAlbumInList(List<Album> albumList, String albumID) {
+
+    for (Album albumPiece : albumList) {
+
+      if (albumPiece.getAlbumID().equals(albumID))
+        return albumPiece;
     }
     return null;
   }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/global/SseEmitters.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/global/SseEmitters.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.noyes.jogakbo.album.Album;
 import com.noyes.jogakbo.user.DTO.Friend;
 
 import lombok.extern.slf4j.Slf4j;
@@ -47,5 +48,32 @@ public class SseEmitters {
     }
 
     return "친구 추가 요청을 완료했습니다.";
+  }
+
+  /**
+   * send SSE alarm to user corresponding `collaboUserID` with `requestAlbum` info
+   * 
+   * @param socialID
+   * @param requestAlbum
+   * @return Result info in String
+   */
+  public String sendAlbumInvitation(String collaboUserID, Album requestAlbum) {
+
+    try {
+
+      this.emitters.get(collaboUserID).send(SseEmitter.event()
+          .name("albumInvitation")
+          .data(requestAlbum));
+
+    } catch (IOException e) {
+
+      throw new RuntimeException(e);
+
+    } catch (NullPointerException npe) {
+
+      return "해당 유저가 오프라인 상태입니다.";
+    }
+
+    return "앨범 초대 요청을 완료했습니다.";
   }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/user/DTO/UserProfile.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/user/DTO/UserProfile.java
@@ -17,4 +17,6 @@ public class UserProfile {
   private List<Friend> sentFriendRequest;
   private List<Friend> receivedFriendRequest;
   private List<Album> albums;
+  private List<Album> collaboAlbums;
+  private List<Album> receivedAlbumInvitations;
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/user/User.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/user/User.java
@@ -35,7 +35,7 @@ public class User {
   // field for collaboration albums list
   private List<Album> collaboAlbums;
   // field for recieved invitation from album owner
-  private List<Album> recievedAlbumInvitations;
+  private List<Album> receivedAlbumInvitations;
 
   @DocumentReference(lazy = true)
   private List<Album> albums;

--- a/jogakbo/src/main/java/com/noyes/jogakbo/user/User.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/user/User.java
@@ -32,6 +32,10 @@ public class User {
   private List<Friend> friends;
   private List<Friend> sentFriendRequests;
   private List<Friend> receivedFriendRequests;
+  // field for collaboration albums list
+  private List<Album> collaboAlbums;
+  // field for recieved invitation from album owner
+  private List<Album> recievedAlbumInvitations;
 
   @DocumentReference(lazy = true)
   private List<Album> albums;

--- a/jogakbo/src/main/java/com/noyes/jogakbo/user/UserService.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/user/UserService.java
@@ -547,4 +547,37 @@ public class UserService {
 
     userRepository.save(user);
   }
+
+  /**
+   * resUserID에 해당하는 유저 Entity의 receivedAlbumInvitations 필드에서 albumID에 해당하는 album
+   * 제거
+   * 
+   * @param collaboUserID
+   * @param album
+   */
+  public void removeAlbumInvitation(@NonNull String resUserID, String albumID) {
+
+    User user = userRepository.findById(resUserID)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 대상입니다."));
+
+    user.getReceivedAlbumInvitations().removeIf(album -> album.getAlbumID().equals(albumID));
+
+    userRepository.save(user);
+  }
+
+  /**
+   * collaboUserID에 해당하는 유저 Entity의 receivedAlbumInvitations 필드에 album을 추가
+   * 
+   * @param collaboUserID
+   * @param album
+   */
+  public void addCollaboAlbum(@NonNull String collaboUserID, Album album) {
+
+    User user = userRepository.findById(collaboUserID)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 대상입니다."));
+
+    user.getCollaboAlbums().add(album);
+
+    userRepository.save(user);
+  }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/user/UserService.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/user/UserService.java
@@ -531,4 +531,20 @@ public class UserService {
 
     return "프로필을 성공적으로 변경했습니다.";
   }
+
+  /**
+   * collaboUserID에 해당하는 유저 Entity의 receivedAlbumInvitations 필드에 album을 추가
+   * 
+   * @param collaboUserID
+   * @param album
+   */
+  public void addReceivedAlbumInvitations(@NonNull String collaboUserID, Album album) {
+
+    User user = userRepository.findById(collaboUserID)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 대상입니다."));
+
+    user.getReceivedAlbumInvitations().add(album);
+
+    userRepository.save(user);
+  }
 }

--- a/jogakbo/src/main/java/com/noyes/jogakbo/user/UserService.java
+++ b/jogakbo/src/main/java/com/noyes/jogakbo/user/UserService.java
@@ -263,6 +263,8 @@ public class UserService {
         .sentFriendRequest(user.getSentFriendRequests())
         .receivedFriendRequest(user.getReceivedFriendRequests())
         .albums(user.getAlbums())
+        .collaboAlbums(user.getCollaboAlbums())
+        .receivedAlbumInvitations(user.getReceivedAlbumInvitations())
         .build();
   }
 


### PR DESCRIPTION
**Related issue**
resolve #42

**Key changes**

> album invitaion API
- validates client is album owner
- returns nothing if already sent request or invited
- sends SSE alarm to target user if online

> album invitation reply API
- validates client is invited by album owner
- only remove sent|received invitation if invitation is expired


**Additional context**


**To Reviewers**

updated db with changes(new fields in entities)
reference: `replyFriendRequest` in `UserController`